### PR TITLE
Overhaul use of device tree

### DIFF
--- a/asm/consts.s
+++ b/asm/consts.s
@@ -1,6 +1,6 @@
 # diosix hypervisor memory locations and layout for common RV32G/RV64G targets
 #
-# (c) Chris Williams, 2018-19.
+# (c) Chris Williams, 2018-2020.
 # See LICENSE for usage and copying.
 
 .equ PAGE_SIZE, (4096)
@@ -27,9 +27,9 @@
 #   .   page of private variables
 #   .   private heap space
 
-# describe per-CPU slab. each slab is 1 << 18 bytes in size = 256KB
+# describe per-CPU slab. each slab is (1 << 19) bytes in size = 512KB
 # update ../src/physmem.rs PHYS_MEM_PER_CPU if HV_CPU_SLAB_SHIFT changes
-.equ HV_CPU_SLAB_SHIFT,         (18)
+.equ HV_CPU_SLAB_SHIFT,         (19)
 .equ HV_CPU_SLAB_SIZE,          (1 << HV_CPU_SLAB_SHIFT)
 .equ HV_CPU_STACK_BASE,         (0)
 .equ HV_CPU_STACK_SIZE,         (32 * 1024)

--- a/asm/entry.s
+++ b/asm/entry.s
@@ -1,8 +1,10 @@
-# diosix hypervisor common low-level entry points for RV32G/RV64G platforms
+# diosix hypervisor common low-level entry points for RV32I/RV64I platforms
 #
-# Assumes a0 = CPU/Hart ID number, a1 -> device tree
+# Assumes on entry: a0 = CPU/Hart ID number, a1 -> device tree
 #
-# (c) Chris Williams, 2019.
+# All values are little endian unless otherwise specified
+#
+# (c) Chris Williams, 2019-2020.
 # See LICENSE for usage and copying.
 
 # _start *must* be the first routine in this file
@@ -76,7 +78,11 @@ _start:
   slli      t2, t1, 21        # set bit 21 = TW (timewout wait)
   csrrs     x0, mstatus, t2
 
-  # call hwentry with runtime-assigned CPU ID number in a0, devicetree in a1
+  # call hwentry with:
+  # a0 = runtime-assigned CPU ID number
+  # a1 = pointer to start of devicetree
+  # a2 = big-endian length of the devicetree
+  lw        a2, 4(a1)       # 32-bit size of tree stored from byte 4 in tree blob
   la        t0, hventry
   jalr      ra, t0, 0
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,6 +1,6 @@
 /* diosix RV32/RV64 physical CPU core management
  *
- * (c) Chris Williams, 2019.
+ * (c) Chris Williams, 2019-2020.
  *
  * See LICENSE for usage and copying.
  */
@@ -205,7 +205,7 @@ impl fmt::Debug for CPUDescription
             64 - 2
         };
 
-        /* extract ISA width from misa to sanity check this CPU.
+        /* extract ISA width from misa to check this CPU.
         bear in mind, if this is a 32-bit hypervisor, it won't
         boot on a 64-bit system and vice versa */
         let isa = match self.misa >> width_shift

--- a/src/errata.rs
+++ b/src/errata.rs
@@ -1,0 +1,35 @@
+/* known errata on RV32/64 systems
+ *
+ * (c) Chris Williams, 2020.
+ *
+ * See LICENSE for usage and copying.
+ */
+
+use alloc::string::String;
+
+/* each bit represents a bug we're aware of that needs mitigating in
+   software. erratum that doesn't need fixing up in the hypervisor
+   shouldn't be listed */
+
+/* system: SiFive HiFive Unleashed A00
+   SOC: FU540-C000
+*/
+// SIFIVE_FU540_C000_ROCK_1 -- ITIM de-allocation corrupts I-cache contents -- N/A
+// SIFIVE_FU540_C000_ROCK_2 -- High 24 address bits are ignored (!)
+// SIFIVE_FU540_C000_ROCK_4 -- DPC CSR is not sign-extended
+const SIFIVE_FU540_C000_ROCK_3:     usize = 0; // E51 CPU atomic operations not ordered correctly
+const SIFIVE_FU540_C000_CCACHE_1:   usize = 1; // L2 ECC failed address reporting flawed
+const SIFIVE_FU540_C000_I2C_1:      usize = 2; // I2C interrupt can not be cleared
+
+pub fn from_model(model: String) -> (u64, u64)
+{
+    let mut known: u64 = 0;
+    let fixed: u64 = 0;
+
+    if model.contains("hifive-unleashed-a00") == true
+    {
+        known = (1 << SIFIVE_FU540_C000_ROCK_3) | (1 << SIFIVE_FU540_C000_CCACHE_1) | (1 << SIFIVE_FU540_C000_I2C_1);
+    }
+
+    (known, fixed)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 /* diosix RV32G/RV64G common hardware-specific code
  *
- * (c) Chris Williams, 2019.
+ * (c) Chris Williams, 2019-2020.
  *
  * See LICENSE for usage and copying.
  */
@@ -24,3 +24,4 @@ pub mod cpu;
 pub mod timer;
 pub mod test;
 pub mod devices;
+pub mod errata;

--- a/src/physmem.rs
+++ b/src/physmem.rs
@@ -1,6 +1,6 @@
 /* diosix RV32G/RV64G code for managing physical memory
  *
- * (c) Chris Williams, 2019.
+ * (c) Chris Williams, 2019-2020.
  *
  * See LICENSE for usage and copying.
  */
@@ -60,7 +60,7 @@ const PHYS_PMP_EXEC: usize  = 1 << 2;
 const PHYS_PMP_TOR: usize   = 1 << 3;
 
 /* each CPU has a fix memory overhead, allocated during boot */
-const PHYS_MEM_PER_CPU: usize = 1 << 18; /* 256KB. see ../asm/const.s */
+const PHYS_MEM_PER_CPU: usize = 1 << 19; /* 512KB. see ../asm/const.s */
 
 /* standardize types for passing around physical RAM addresses */
 pub type PhysMemBase = usize;
@@ -133,7 +133,7 @@ impl Iterator for RAMAreaIter
     /* return a physical RAM area or None to end iteration */
     fn next(&mut self) -> Option<RAMArea>
     {
-        /* if for some reason the iterator starts below phys RAM, bring it up to sanity */
+        /* if for some reason the iterator starts below phys RAM, bring it up to reality */
         if self.pos < self.total_area.base
         {
             self.pos = self.total_area.base

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,12 +1,11 @@
 /* diosix RV32G/RV64G hardware serial controller
  *
- * (c) Chris Williams, 2019-2020
+ * (c) Chris Williams, 2019-2020.
  *
  * See LICENSE for usage and copying.
  */
 
 use core::ptr::write_volatile;
-use alloc::string::String;
 
 /* serial port controller registers, relative to the base address */
 const TXDATA: usize = 0x0;     /* write a byte here to transmit it over the port */
@@ -64,14 +63,14 @@ impl SerialPort
     }
 }
 
-/* hard-coded debugging on Qemu platform */
+/* emergency debugging functions hard-coded for the Qemu platform. do not use on real hardware */
 use core::fmt;
 
 #[macro_export]
 macro_rules! qprintln
 {
-    ($fmt:expr) => (qprint!(concat!($fmt, "\n")));
-    ($fmt:expr, $($arg:tt)*) => (qprint!(concat!($fmt, "\n"), $($arg)*));
+    ($fmt:expr) => ($crate::qprint!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => ($crate::qprint!(concat!($fmt, "\n"), $($arg)*));
 }
 
 #[macro_export]


### PR DESCRIPTION
A number of changes:
* Increase per-physical-CPU core heap to 512KB
* Add support for CPU errata
* Use Rust-safe device tree parser